### PR TITLE
[FEAT]: Exclude files

### DIFF
--- a/app/Commands/InitCommand.php
+++ b/app/Commands/InitCommand.php
@@ -8,6 +8,7 @@ use App\Formatters\StudlyCaseFormatter;
 use App\Formatters\TitleFormatter;
 use App\Formatters\UpperCaseFormatter;
 use Illuminate\Contracts\Console\PromptsForMissingInput;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
@@ -31,6 +32,7 @@ class InitCommand extends Command implements PromptsForMissingInput
                             { author-email : The author\'s email }
                             { description : The plugin description }
                             { --p|path= : Path to the plugin directory }
+                            { --exclude=* : Paths to exclude }
                             { --d|dont-delete-cli : Prevent deleting the CLI }';
 
     protected $description = 'Initialize the plugin development package';
@@ -39,6 +41,12 @@ class InitCommand extends Command implements PromptsForMissingInput
         'build',
         'vendor',
         'node_modules',
+    ];
+
+    protected array $excludedFiles = [
+        'phpunit.xml',
+        'package.json',
+        'testbench.yaml',
     ];
 
     public function __construct()
@@ -145,6 +153,8 @@ class InitCommand extends Command implements PromptsForMissingInput
         return (new Finder)
             ->in($this->getPackageDirectories())
             ->files()
+            ->notPath($this->getExcludedPaths())
+            ->ignoreDotFiles(true)
             ->exclude($this->getExcludedDirectories());
     }
 
@@ -158,6 +168,13 @@ class InitCommand extends Command implements PromptsForMissingInput
     protected function getExcludedDirectories(): array
     {
         return $this->excludedDirectories;
+    }
+
+    protected function getExcludedPaths(): array
+    {
+        $excludedPaths = Arr::wrap($this->option('exclude'));
+
+        return array_merge($this->excludedFiles, $excludedPaths);
     }
 
     protected function initFile(SplFileInfo $file): void

--- a/tests/Feature/Commands/InitCommandTest.php
+++ b/tests/Feature/Commands/InitCommandTest.php
@@ -153,6 +153,25 @@ it('replace file name', function () {
         ->toBeTrue();
 });
 
+it('replace nothing', function () {
+    \Illuminate\Support\Sleep::fake();
+
+    $this->getTestingDisk()->put('phpunit.xml', '');
+    $this->getTestingDisk()->put('package.json', '');
+    $this->getTestingDisk()->put('testbench.yaml', '');
+    $this->getTestingDisk()->put('ExampleClass.php', '');
+
+    $this->artisan('init', [...$this->commandConfig, '--exclude' => 'ExampleClass.php'])
+        ->doesntExpectOutputToContain('Replacing placeholders in file [phpunit.xml]')
+        ->doesntExpectOutputToContain('Replacing placeholders in file [package.json]')
+        ->doesntExpectOutputToContain('Replacing placeholders in file [testbench.yaml]')
+        ->assertSuccessful();
+
+    \Illuminate\Support\Sleep::assertSleptTimes(0);
+
+    expect($this->getTestingDisk()->files())->toHaveCount(4);
+});
+
 it('remove tags', function () {
     // Arrange
     \Illuminate\Support\Sleep::fake();


### PR DESCRIPTION
Exclude three default paths: `phpunit.xml`, `package.json` and `testbench.yaml`. This feature also includes the flag `--exclude` to exclude paths from the process