### PR TITLE
[FIX]: Regex to fix removal when the `tag`

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -25,7 +25,7 @@ use Illuminate\Support\Str;
 function removeTag(string $tag, string $content): string
 {
     return Str::of($content)
-        ->replaceMatches('/\n*?<!--'.$tag.'-->.*?<!--\/'.$tag.'-->\n*?/s', '')
+        ->replaceMatches('/(?(?=\s*#)\s*#\s*|\s*)<!--'.$tag.'-->.*?<!--\/'.$tag.'-->/s', '')
         ->toString();
 }
 


### PR DESCRIPTION
If the `tag` is not inside an HTML or MD, those mark-up languages don't render the tag, so If you want to include it inside a `comment` the `tag` should come between `#` and some space.

e.g. \# `<!--DELETE-->...<!--/DELETE-->`